### PR TITLE
feat: 支持配置易支付前台渠道

### DIFF
--- a/lib/validators/payment.ts
+++ b/lib/validators/payment.ts
@@ -1,4 +1,5 @@
 import { badRequestError } from "../app-error";
+import { isEpayChannel, normalizeEpayChannels } from "../../modules/payment/epay-channels";
 
 export function validatePaymentConfigInput(input: {
   name?: string;
@@ -8,6 +9,7 @@ export function validatePaymentConfigInput(input: {
   appSecret?: string;
   pid?: string;
   key?: string;
+  epayChannels?: string[];
   alipayAppId?: string;
   alipayPrivateKey?: string;
   alipayPublicKey?: string;
@@ -26,12 +28,21 @@ export function validatePaymentConfigInput(input: {
     throw badRequestError("启用 BEpusdt 时必须填写 App Secret", "BEPUSDT_APP_SECRET_REQUIRED");
   }
 
-  if (input.provider === "EPAY" && input.isEnabled !== false) {
-    if (!(input.pid?.trim())) {
-      throw badRequestError("启用 Epay 时必须填写 PID", "EPAY_PID_REQUIRED");
+  if (input.provider === "EPAY") {
+    if (input.epayChannels !== undefined && (!Array.isArray(input.epayChannels) || input.epayChannels.some((channel) => !isEpayChannel(channel)))) {
+      throw badRequestError("易支付渠道配置无效", "EPAY_CHANNEL_INVALID");
     }
-    if (!(input.key?.trim())) {
-      throw badRequestError("启用 Epay 时必须填写 Key", "EPAY_KEY_REQUIRED");
+
+    if (input.isEnabled !== false) {
+      if (!(input.pid?.trim())) {
+        throw badRequestError("启用 Epay 时必须填写 PID", "EPAY_PID_REQUIRED");
+      }
+      if (!(input.key?.trim())) {
+        throw badRequestError("启用 Epay 时必须填写 Key", "EPAY_KEY_REQUIRED");
+      }
+      if (normalizeEpayChannels(input.epayChannels).length === 0) {
+        throw badRequestError("启用 Epay 时至少选择一个支付渠道", "EPAY_CHANNEL_REQUIRED");
+      }
     }
   }
 

--- a/modules/order/service.ts
+++ b/modules/order/service.ts
@@ -5,7 +5,8 @@ import { badRequestError, conflictError, notFoundError } from "../../lib/app-err
 import { validateOrderInput } from "../../lib/validators/order";
 import { getAdminContext, logAdminOperation } from "../auth/service";
 import { getAdminProductById } from "../catalog/service";
-import { createPaymentForOrder, handlePaymentNotify } from "../payment/service";
+import { createPaymentForOrder, getPaymentConfigs, handlePaymentNotify } from "../payment/service";
+import { resolveEpayChannel } from "../payment/epay-channels";
 import { deliverOrder } from "../delivery/service";
 import { closeOrderRecord, createOrderRecord, findOrderById, findOrderWithProduct, listOrderRecords } from "./repository";
 import { generateOrderNo, generateQueryToken } from "./number";
@@ -94,7 +95,11 @@ export async function createOrder(input: {
   const queryToken = generateQueryToken();
   let paymentChannel: string | null = null;
   if (input.paymentProvider === "EPAY") {
-    paymentChannel = input.paymentChannel === "wxpay" ? "wxpay" : "alipay";
+    const paymentConfigs = await getPaymentConfigs(prisma);
+    paymentChannel = resolveEpayChannel(paymentConfigs.EPAY.epayChannels, input.paymentChannel);
+    if (!paymentChannel) {
+      throw badRequestError("所选易支付渠道当前未启用", "EPAY_CHANNEL_DISABLED");
+    }
   } else if (input.paymentProvider === "ALIPAY") {
     paymentChannel = input.paymentChannel ?? "alipay_h5";
   }

--- a/modules/payment/epay-channels.ts
+++ b/modules/payment/epay-channels.ts
@@ -1,0 +1,28 @@
+export const EPAY_CHANNEL_OPTIONS = [
+  { value: "alipay", label: "支付宝" },
+  { value: "wxpay", label: "微信支付" },
+] as const;
+
+export type EpayChannel = (typeof EPAY_CHANNEL_OPTIONS)[number]["value"];
+
+export const DEFAULT_EPAY_CHANNELS: EpayChannel[] = EPAY_CHANNEL_OPTIONS.map((channel) => channel.value);
+
+export function isEpayChannel(value: unknown): value is EpayChannel {
+  return EPAY_CHANNEL_OPTIONS.some((channel) => channel.value === value);
+}
+
+export function normalizeEpayChannels(value: unknown): EpayChannel[] {
+  if (!Array.isArray(value)) {
+    return [...DEFAULT_EPAY_CHANNELS];
+  }
+
+  return EPAY_CHANNEL_OPTIONS
+    .map((channel) => channel.value)
+    .filter((channel) => value.includes(channel));
+}
+
+export function resolveEpayChannel(enabledChannels: unknown, requestedChannel: unknown): EpayChannel | null {
+  const channels = normalizeEpayChannels(enabledChannels);
+  const requested = isEpayChannel(requestedChannel) ? requestedChannel : channels[0];
+  return requested && channels.includes(requested) ? requested : null;
+}

--- a/modules/payment/service.ts
+++ b/modules/payment/service.ts
@@ -17,6 +17,7 @@ import { createStripeAdapter } from "./stripe";
 import { createHashpayAdapter } from "./hashpay";
 import { deliverOrder } from "../delivery/service";
 import { findOrderRecord, updateOrderPayment } from "../order/repository";
+import { DEFAULT_EPAY_CHANNELS, normalizeEpayChannels, resolveEpayChannel } from "./epay-channels";
 
 const defaultPaymentConfigs: Record<PaymentProvider, PaymentConfigValue> = {
   BEPUSDT: {
@@ -36,6 +37,7 @@ const defaultPaymentConfigs: Record<PaymentProvider, PaymentConfigValue> = {
     baseUrl: "",
     pid: "",
     key: "",
+    epayChannels: [...DEFAULT_EPAY_CHANNELS],
     notifyUrl: "/api/payments/epay/notify",
     returnUrl: "/order/{orderNo}?token={token}",
   },
@@ -105,13 +107,17 @@ function normalizePaymentConfig(record: Awaited<ReturnType<typeof getPaymentConf
 
   try {
     const parsed = JSON.parse(record.configJson) as Partial<PaymentConfigValue>;
-    return {
+    const value = {
       ...defaults,
       ...parsed,
       provider,
       name: record.name,
       isEnabled: record.isEnabled,
     };
+    if (provider === "EPAY") {
+      value.epayChannels = normalizeEpayChannels(parsed.epayChannels);
+    }
+    return value;
   } catch {
     return {
       ...defaults,
@@ -133,6 +139,7 @@ export async function listEnabledPaymentMethods(prisma?: PrismaClient): Promise<
       label: value.name,
       enabled: value.isEnabled,
       baseUrl: value.baseUrl,
+      epayChannels: provider === "EPAY" ? normalizeEpayChannels(value.epayChannels) : undefined,
     };
   });
 }
@@ -159,6 +166,7 @@ export async function savePaymentConfig(input: PaymentConfigValue) {
     appSecret: input.appSecret?.trim() || "",
     pid: input.pid?.trim() || "",
     key: input.key?.trim() || "",
+    ...(input.provider === "EPAY" ? { epayChannels: normalizeEpayChannels(input.epayChannels) } : {}),
     notifyUrl: input.notifyUrl?.trim() || "",
     returnUrl: input.returnUrl?.trim() || "",
     alipayAppId: input.alipayAppId?.trim() || "",
@@ -265,6 +273,13 @@ export async function createPaymentForOrder(orderNo: string, prisma?: PrismaClie
     throw badRequestError(`${config.name} 缺少网关地址配置`, "PAYMENT_PROVIDER_BASE_URL_MISSING");
   }
 
+  const paymentChannel = order.paymentProvider === "EPAY"
+    ? resolveEpayChannel(config.epayChannels, order.paymentChannel)
+    : order.paymentChannel ?? undefined;
+  if (order.paymentProvider === "EPAY" && !paymentChannel) {
+    throw conflictError("所选易支付渠道当前未启用", "EPAY_CHANNEL_DISABLED");
+  }
+
   const adapter = createProviderAdapter(config);
   const baseOrigin = await getBaseOrigin(client);
   const templateValues = {
@@ -289,7 +304,7 @@ export async function createPaymentForOrder(orderNo: string, prisma?: PrismaClie
     productName: order.productNameSnapshot,
     notifyUrl,
     returnUrl,
-    paymentChannel: order.paymentChannel ?? undefined,
+    paymentChannel: paymentChannel ?? undefined,
   });
 
   if (result.paymentOrderNo) {

--- a/modules/payment/types.ts
+++ b/modules/payment/types.ts
@@ -1,3 +1,5 @@
+import type { EpayChannel } from "./epay-channels";
+
 export type PaymentProvider = "BEPUSDT" | "EPAY" | "ALIPAY" | "ALIPAY_FACE" | "STRIPE" | "FREE_PAY" | "HASHPAY";
 
 export interface PaymentMethodItem {
@@ -5,6 +7,7 @@ export interface PaymentMethodItem {
   label: string;
   enabled: boolean;
   baseUrl?: string;
+  epayChannels?: EpayChannel[];
 }
 
 export interface PaymentConfigValue {
@@ -16,6 +19,7 @@ export interface PaymentConfigValue {
   appSecret?: string;
   pid?: string;
   key?: string;
+  epayChannels?: EpayChannel[];
   notifyUrl?: string;
   returnUrl?: string;
   alipayAppId?: string;

--- a/pages/admin/payments/PaymentConfigCard.vue
+++ b/pages/admin/payments/PaymentConfigCard.vue
@@ -57,6 +57,7 @@ import AlipayFaceForm from "./forms/AlipayFaceForm.vue";
 import StripeForm from "./forms/StripeForm.vue";
 import HashpayForm from "./forms/HashpayForm.vue";
 import type { PaymentProvider, PaymentConfigValue } from "../../../modules/payment/types";
+import { DEFAULT_EPAY_CHANNELS } from "../../../modules/payment/epay-channels";
 
 const formMap: Record<string, any> = { BEPUSDT: BEpusdtForm, EPAY: EpayForm, ALIPAY: AlipayForm, ALIPAY_FACE: AlipayFaceForm, STRIPE: StripeForm, HASHPAY: HashpayForm };
 
@@ -78,7 +79,7 @@ const form = reactive({
 
 const extraFieldsMap: Record<string, () => Record<string, any>> = {
   BEPUSDT: () => ({ appId: props.initialValue?.appId ?? '', appSecret: props.initialValue?.appSecret ?? '' }),
-  EPAY: () => ({ pid: props.initialValue?.pid ?? '', key: props.initialValue?.key ?? '' }),
+  EPAY: () => ({ pid: props.initialValue?.pid ?? '', key: props.initialValue?.key ?? '', epayChannels: props.initialValue?.epayChannels ?? [...DEFAULT_EPAY_CHANNELS] }),
   ALIPAY: () => ({ alipayAppId: props.initialValue?.alipayAppId ?? '', alipayPrivateKey: props.initialValue?.alipayPrivateKey ?? '', alipayPublicKey: props.initialValue?.alipayPublicKey ?? '' }),
   ALIPAY_FACE: () => ({ alipayAppId: props.initialValue?.alipayAppId ?? '', alipayPrivateKey: props.initialValue?.alipayPrivateKey ?? '', alipayPublicKey: props.initialValue?.alipayPublicKey ?? '' }),
   STRIPE: () => ({ stripeSecretKey: props.initialValue?.stripeSecretKey ?? '', stripeWebhookSecret: props.initialValue?.stripeWebhookSecret ?? '', stripeCurrency: props.initialValue?.stripeCurrency ?? 'cny' }),

--- a/pages/admin/payments/forms/EpayForm.vue
+++ b/pages/admin/payments/forms/EpayForm.vue
@@ -9,6 +9,16 @@
       <SecretInput v-model="modelValue.key" />
     </label>
   </div>
+  <fieldset class="space-y-2">
+    <legend class="label-text font-medium">前台支付渠道</legend>
+    <div class="flex flex-wrap gap-4">
+      <label v-for="channel in EPAY_CHANNEL_OPTIONS" :key="channel.value" class="label cursor-pointer gap-2">
+        <input v-model="modelValue.epayChannels" type="checkbox" class="checkbox checkbox-primary checkbox-sm" :value="channel.value" />
+        <span class="label-text">{{ channel.label }}</span>
+      </label>
+    </div>
+    <p class="text-xs text-base-content/60">仅勾选网关实际支持的渠道；启用易支付时至少选择一项。</p>
+  </fieldset>
   <p class="text-xs text-base-content/60">
     `Notify URL` 和 `Return URL` 支持填写相对路径或完整 URL；`Return URL` 支持 `{orderNo}`、`{token}` 占位符。
   </p>
@@ -16,5 +26,6 @@
 
 <script setup lang="ts">
 import SecretInput from "../../../../components/SecretInput.vue";
+import { EPAY_CHANNEL_OPTIONS } from "../../../../modules/payment/epay-channels";
 defineProps<{ modelValue: Record<string, any> }>();
 </script>

--- a/pages/admin/payments/savePaymentConfig.telefunc.ts
+++ b/pages/admin/payments/savePaymentConfig.telefunc.ts
@@ -2,6 +2,7 @@ import { assertAdminAccess } from "../../../modules/auth/service";
 import { savePaymentConfig } from "../../../modules/payment/service";
 import { throwAbortError } from "../../../lib/throw-abort-error";
 import type { PaymentProvider } from "../../../modules/payment/types";
+import type { EpayChannel } from "../../../modules/payment/epay-channels";
 
 export async function onSavePaymentConfig(input: {
   provider: PaymentProvider;
@@ -12,6 +13,7 @@ export async function onSavePaymentConfig(input: {
   appSecret?: string;
   pid?: string;
   key?: string;
+  epayChannels?: EpayChannel[];
   notifyUrl?: string;
   returnUrl?: string;
   alipayAppId?: string;

--- a/pages/product/@slug/+Page.vue
+++ b/pages/product/@slug/+Page.vue
@@ -188,6 +188,7 @@ import { onCreateOrder } from "./createOrder.telefunc";
 import { onPreviewDiscount } from "./previewDiscount.telefunc";
 import type { PaymentProvider } from "../../../modules/payment/types";
 import { isMobile } from "../../../lib/utils/device";
+import { EPAY_CHANNEL_OPTIONS, normalizeEpayChannels } from "../../../modules/payment/epay-channels";
 
 import { saveLocalOrder } from "../../../lib/local-orders";
 import type { Data } from "./+data";
@@ -199,10 +200,13 @@ const submitting = ref(false);
 const errorMessage = ref("");
 const descriptionRef = ref<HTMLElement | null>(null);
 const previewImage = ref<{ src: string; alt: string } | null>(null);
-const epayChannels = [
-  { value: "alipay", label: "支付宝", icon: "alipay" },
-  { value: "wxpay", label: "微信", icon: "wechat" },
-] as const;
+const epayChannels = computed(() => {
+  const method = paymentMethods.find((item) => item.provider === "EPAY");
+  const enabledChannels = normalizeEpayChannels(method?.epayChannels);
+  return EPAY_CHANNEL_OPTIONS
+    .filter((channel) => enabledChannels.includes(channel.value))
+    .map((channel) => ({ ...channel, icon: channel.value === "alipay" ? "alipay" : "wechat" }));
+});
 
 const discountPreview = reactive({
   loading: false,
@@ -229,7 +233,7 @@ function getDeliveryTypeLabel(type: string) {
 let mobile = false;
 
 function getDefaultPaymentChannel(provider: PaymentProvider | "") {
-  if (provider === "EPAY") return "alipay";
+  if (provider === "EPAY") return epayChannels.value[0]?.value ?? "";
   if (provider === "ALIPAY") return mobile ? "alipay_h5" : "alipay_pc";
   if (provider === "ALIPAY_FACE") return "";
   return "";
@@ -388,5 +392,4 @@ function escapeHtml(value: string) {
     .replace(/'/g, "&#39;");
 }
 </script>
-
 


### PR DESCRIPTION
## 变更内容

- 在易支付后台配置中增加支付宝、微信支付渠道选择
- 商品页仅展示管理员启用的易支付渠道，并默认选中首个可用渠道
- 保存配置、创建订单和创建支付时校验渠道白名单，阻止提交已禁用渠道
- 兼容已有配置：未保存渠道字段时默认启用支付宝和微信支付，无需数据库迁移

## 验证

- `npx tsc --noEmit`
- `npx vike build`
- 实际部署验证仅启用支付宝时，商品页只渲染支付宝渠道
- 验证已禁用的微信渠道会被服务端拒绝